### PR TITLE
Remove tracking param from attachment url

### DIFF
--- a/plugins/transport/file.js
+++ b/plugins/transport/file.js
@@ -28,6 +28,7 @@ const USERAGENT = `LilyWhiteBot/${pkg.version} (${pkg.repository})`;
  * @returns {string} 新文件名
  */
 const generateFileName = (url, name) => {
+    url = url.replace(/\?.*$/, ''); // removing tracking param, issue with discord attachments
     let extName = path.extname(name || '');
     if (extName === '') {
         extName = path.extname(url || '');


### PR DESCRIPTION
Discord starts adding tracking parameters in attachment url (looks like ?ex=0&is=0&hm=0), so remove them to avoid them mess-up file ext name